### PR TITLE
Fix space handling in directory paths and POSIX compatibility

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,17 +1,16 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 NAME='markdown-to-pdf-with-plantuml'
 
-if [[ "$(docker images -q $NAME 2> /dev/null)" == "" ]]; then
-    docker build -t $NAME .
+if [ "$(docker images -q $NAME 2> /dev/null)" = "" ]; then
+    docker build -t $NAME . || exit 1
 fi
 
-DIRECTORY_TO_VOLUME=$1
+DIRECTORY_TO_VOLUME="$1"
 
-if [ -z "$DIRECTORY_TO_VOLUME" ]
-then
-    echo "Please provide path to the directory with files to build"
-    exit 0
+if [ -z "$DIRECTORY_TO_VOLUME" ]; then
+    echo "Please provide path to the directory with files to build" >&2
+    exit 1
 fi
 
-docker run -v $DIRECTORY_TO_VOLUME:/var/doc $NAME /var/build.sh
+docker run -v "$DIRECTORY_TO_VOLUME":/var/doc $NAME /var/build.sh || exit 1


### PR DESCRIPTION
Quotes the DIRECTORY_TO_VOLUME variable to make sure the script supports paths that contain spaces or other reversed characters that would otherwise get expanded by the shell executing the script.

Updates error handling to ensure that the correct exit code is returned to the user, and directs the messages to STDERR rather than STDOUT.

README lists POSIX shell as a requirement, but currently the run.sh requires bash. The script is mostly compatible, but did need few syntax changes to make it truly POSIX compliant. Now any POSIX shell should be able to run the script.