### PR TITLE
Use Ubuntu "jammy" instead of "groovy"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:groovy
+FROM ubuntu:jammy
 
 # combine into one run command to reduce image size
 RUN apt-get update


### PR DESCRIPTION
I was unable to build this tool since Ubuntu Jammy is EOL and the security updates mirror that is contacted for package updates is no longer available.

It seems upgrading to Ubuntu Groovy avoids this error, although my build is not yet finished and I cannot tell for sure if everything works.